### PR TITLE
Interpolate Now Takes Any IntoIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2020-01-23
+### Changed
+- Sharks recover method now accepts any iterable collection
+
 ## [0.3.0] - 2020-01-22
 ### Added
 - Share struct which allows to convert from/to byte vectors

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sharks"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Aitor Ruano <codearm@pm.me>"]
 description = "Fast, small and secure Shamir's Secret Sharing library crate"
 homepage = "https://github.com/c0dearm/sharks"

--- a/src/field.rs
+++ b/src/field.rs
@@ -58,7 +58,7 @@ const EXP_TABLE: [u8; 512] = [
     0x58, 0xb0, 0x7d, 0xfa, 0xe9, 0xcf, 0x83, 0x1b, 0x36, 0x6c, 0xd8, 0xad, 0x47, 0x8e, 0x01, 0x02,
 ];
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub struct GF256(pub u8);
 
 #[allow(clippy::suspicious_arithmetic_impl)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ impl Sharks {
         math::get_evaluator(polys)
     }
 
-    /// Given a collection of shares, recovers the original secret.
+    /// Given an iterable collection of shares, recovers the original secret.
     /// If the number of distinct shares is less than the minimum threshold an `Err` is returned,
     /// otherwise an `Ok` containing the secret.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,13 @@ impl Sharks {
     /// secret = sharks.recover(&shares);
     /// // Not enough shares to recover secret
     /// assert!(secret.is_err());
-    pub fn recover(&self, shares: &[Share]) -> Result<Vec<u8>, &str> {
-        let shares_x: HashSet<u8> = shares.iter().map(|s| s.x.0).collect();
+    pub fn recover<'a, I, J>(&self, shares: I) -> Result<Vec<u8>, &str>
+    where
+        I: IntoIterator<Item = &'a Share, IntoIter = J>,
+        J: Iterator<Item = &'a Share> + Clone,
+    {
+        let shares = shares.into_iter();
+        let shares_x: HashSet<u8> = shares.clone().map(|s| s.x.0).collect();
 
         if shares_x.len() < self.0 as usize {
             Err("Not enough shares to recover original secret")

--- a/src/math.rs
+++ b/src/math.rs
@@ -9,14 +9,25 @@ use super::share::Share;
 // The expected `shares` argument format is the same as the output by the `get_evaluator´ function.
 // Where each (key, value) pair corresponds to one share, where the key is the `x` and the value is a vector of `y`,
 // where each element corresponds to one of the secret's byte chunks.
-pub fn interpolate(shares: &[Share]) -> Vec<u8> {
-    (0..shares[0].y.len())
+pub fn interpolate<'a, I, J>(shares: I) -> Vec<u8>
+where
+    I: IntoIterator<Item = &'a Share, IntoIter = J>,
+    J: Iterator<Item = &'a Share> + Clone,
+{
+    let shares = shares.into_iter();
+    (0..shares
+        .clone()
+        .peekable()
+        .peek()
+        .expect("There should be at least one share")
+        .y
+        .len())
         .map(|s| {
             shares
-                .iter()
+                .clone()
                 .map(|s_i| {
                     shares
-                        .iter()
+                        .clone()
                         .filter(|s_j| s_j.x != s_i.x)
                         .map(|s_j| s_j.x / (s_j.x - s_i.x))
                         .product::<GF256>()

--- a/src/math.rs
+++ b/src/math.rs
@@ -9,25 +9,14 @@ use super::share::Share;
 // The expected `shares` argument format is the same as the output by the `get_evaluator´ function.
 // Where each (key, value) pair corresponds to one share, where the key is the `x` and the value is a vector of `y`,
 // where each element corresponds to one of the secret's byte chunks.
-pub fn interpolate<'a, I, J>(shares: I) -> Vec<u8>
-where
-    I: IntoIterator<Item = &'a Share, IntoIter = J>,
-    J: Iterator<Item = &'a Share> + Clone,
-{
-    let shares = shares.into_iter();
-    (0..shares
-        .clone()
-        .peekable()
-        .peek()
-        .expect("There should be at least one share")
-        .y
-        .len())
+pub fn interpolate(shares: &[Share]) -> Vec<u8> {
+    (0..shares[0].y.len())
         .map(|s| {
             shares
-                .clone()
+                .iter()
                 .map(|s_i| {
                     shares
-                        .clone()
+                        .iter()
                         .filter(|s_j| s_j.x != s_i.x)
                         .map(|s_j| s_j.x / (s_j.x - s_i.x))
                         .product::<GF256>()


### PR DESCRIPTION
Modified Interpolate to be able to take any struct that implements IntoIterator.

This means that you can pass a `slice` as before, but you can also pass pretty much anything that can generate an iterator of `Share` (like a `HashSet` or a `Map` that comes from iterator operations). It's simply more generic.

One thing to note is that every `clone()` operation are on the `Iterator` itself and not on the data underneath. Since the actual code generates a new `Iterator` instead of simply cloning a starting point, this version also theoretically faster and no sensitive data is copied.