### PR TITLE
WASM bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,17 @@ codecov = { repository = "https://github.com/c0dearm/sharks" }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 rand = "0.7"
+
+[target.'cfg(target_arch="wasm32")'.dependencies]
+serde = "1.0.104"
+serde_derive = "1.0.104"
+rand = { version = "0.7", features = ["wasm-bindgen"] }
+wasm-bindgen = { version = "0.2.58", features = ["serde-serialize"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ mod field;
 mod math;
 mod share;
 
+#[cfg(target_arch = "wasm32")]
+pub mod wasm;
+
 use std::collections::HashSet;
 
 use field::GF256;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,22 @@
+use wasm_bindgen::prelude::*;
+
+use crate::{ Sharks, Share };
+
+#[wasm_bindgen]
+pub fn generate_shares(n_shares: u8, threshold: u8, secret: &[u8]) -> JsValue {
+    let sharks = Sharks(threshold);
+    let dealer = sharks.dealer(secret);
+    let shares: Vec<Vec<u8>> = dealer.take(n_shares as usize).map(|s| (&s).into()).collect();
+
+    JsValue::from_serde(&shares).expect("A Vec<Vec<u8>> should always be JSON serializable.")
+}
+
+#[wasm_bindgen]
+pub fn recover(threshold: u8, shares: JsValue) -> Vec<u8> {
+    let sharks = Sharks(threshold);
+
+    let shares: Vec<Vec<u8>> = shares.into_serde().expect("will implement proper error handling later");
+
+    let shares: Vec<Share> = shares.iter().map(|s| s.as_slice().into()).collect();
+    sharks.recover(&shares).expect("will implement proper error handling later").into()
+}


### PR DESCRIPTION
This PR implements a WASM interface to be used in a browser as an NPM module.

For now it's a draft because a couple of things are missing and might require work in the library to do right (Error handling requires use of actual `Error` to get right, for example).

In the actual state, it is working, even if the code quality is not enough to merge now. Here is how to use it:

1. Install wasm-pack
`cargo install wasm-pack`
2. Add ~/.cargo/bin to your $PATH.
3. Build
`wasm-pack build`
4. Create a nodejs project and add the crate as a dependency in packages.json:
`"sharks": "file:../pkg/"`
5. Import your wrapper asynchronously, since WASM cannot be run synchronously at the moment. For example:
`import("./sharks_wrapper.js");`
6. Here is a working piece of code:
```javascript
import {generate_shares, recover} from "sharks";

var secret = Uint8Array.of(1, 2, 3, 4)

var test = generate_shares(5, 3, secret);

var secret2 = recover(3, test);

alert(secret2);
```