### PR TITLE
fix: show TryFrom trait import in doc

### DIFF
--- a/src/share.rs
+++ b/src/share.rs
@@ -10,8 +10,8 @@ use arbitrary::Arbitrary;
 /// Usage example:
 /// ```
 /// use sharks::{Sharks, Share};
+/// use core::convert::TryFrom;
 /// # use rand_chacha::rand_core::SeedableRng;
-/// # use core::convert::TryFrom;
 /// # fn send_to_printer(_: Vec<u8>) {}
 /// # fn ask_shares() -> Vec<Vec<u8>> {vec![vec![1, 2], vec![2, 3], vec![3, 4]]}
 ///


### PR DESCRIPTION
The `TryFrom` trait import was originally hidden in the example.
However, to make the `try_from` method work correctly, the trait `TryFrom` needs to be used in the code.
So I fix the code in the doc.